### PR TITLE
Add curly braces around Scrollchor in `import`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install react-scrollchor --save
 ## Usage
 
 ```javascript
-import Scrollchor from 'react-scrollchor';
+import { Scrollchor } from 'react-scrollchor';
 ```
 ```javascript
 export default (props) => (


### PR DESCRIPTION
Greetings!

A coworker of mine was attempting to use Scrollchor within a React + Webpack 2 environment, and we found that the `import` statement for Scrollchor in the README wasn't working. We realized that the `Scrollchor` symbol was a non-default export and hence modified our `import` as in this example—which worked!

Cheers,
Joe
