### PR TITLE
Importing PropTypes from prop-types rather than react

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,18 +32,19 @@
   },
   "devDependencies": {
     "babel-cli": "6.x.x",
+    "babel-plugin-transform-class-properties": "6.x.x",
+    "babel-plugin-transform-export-extensions": "6.x.x",
+    "babel-plugin-transform-object-rest-spread": "6.x.x",
     "babel-preset-es2015": "6.x.x",
     "babel-preset-react": "6.x.x",
     "babel-preset-stage-3": "6.x.x",
-    "babel-plugin-transform-class-properties": "6.x.x",
-    "babel-plugin-transform-object-rest-spread": "6.x.x",
-    "babel-plugin-transform-export-extensions": "6.x.x",
     "eslint": "3.x.x",
     "eslint-config-standard-deviation": "1.x.x",
     "eslint-modules-standard-deviation": "1.x.x",
-    "rimraf": "2.x.x",
-    "react": "15.x.x",
     "fbjs": "*",
-    "mkdirp": "*"
+    "mkdirp": "*",
+    "prop-types": "^15.5.8",
+    "react": "15.x.x",
+    "rimraf": "2.x.x"
   }
 }

--- a/src/scrollchor.jsx
+++ b/src/scrollchor.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types'
 import warning from 'fbjs/lib/warning';
 import { getScrollTop, setScrollTop, getOffsetTop } from './utils';
 


### PR DESCRIPTION
React.PropTypes is deprecated as of React v15.5. Updated to use the prop-types library. 